### PR TITLE
Add padding to bottom of work item description

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,36 +6,29 @@ labels: 'bug'
 assignees: ''
 
 ---
+**Your Show Name:**
+Adding your show name helps in reproducing the bug.
 
-**Describe the bug**
+**Describe the bug:**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**To Reproduce:**
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '...'
 3. Scroll down to '...'
 4. See error
 
-**Your Show Name**
-Adding your show name helps in reproducing the bug.
-
-**Expected behavior**
+**Expected behavior:**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+**Screenshots:**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+**Desktop (if issue is seen on desktop, otherwise N/A):**
  - OS: [e.g. Windows]
  - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+**Smartphone (if issue is seen on mobile, otherwise N/A):**
  - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
-**Additional context**
-Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,8 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+**Is your feature request related to a problem? Please describe:**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+**Describe the solution you'd like:**
 A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.

--- a/remote-falcon-web/src/config.js
+++ b/remote-falcon-web/src/config.js
@@ -7,7 +7,7 @@ export const BASE_PATH = '';
 
 export const CONTROL_PANEL_PATH = '/control-panel';
 
-export const VERSION = '1.2.1';
+export const VERSION = '#{Build.BuildNumber}#';
 
 const config = {
   fontFamily: `'Roboto', sans-serif`,

--- a/remote-falcon-web/src/views/pages/controlPanel/tracker/ViewWorkItem.js
+++ b/remote-falcon-web/src/views/pages/controlPanel/tracker/ViewWorkItem.js
@@ -85,7 +85,7 @@ const ViewWorkItem = ({ workItem, coreInfo, open, handleDrawerOpen }) => {
           </Box>
           <Divider />
           <PerfectScrollbar options={{ wheelPropagation: false }}>
-            <Box sx={{ p: 3 }}>
+            <Box sx={{ p: 3, pb: 15 }}>
               <Grid container alignItems="center" spacing={0.5} justifyContent="space-between">
                 <Grid item sx={{ width: 'calc(100% - 50px)' }}>
                   <ReactMarkdown remarkPlugins={[remarkBreaks]}>{workItem?.body}</ReactMarkdown>


### PR DESCRIPTION
- Added some padding to bottom of work item description to prevent it from getting cut off on mobile.
- Simplified the bug and feature templates.
- Now using the build number from CI/CD pipeline as the version number, cause I constantly forget to update it...