### PR TITLE
Add table lock when getting active viewer.

### DIFF
--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/controller/ViewerPageController.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/controller/ViewerPageController.java
@@ -1,25 +1,24 @@
 package com.remotefalcon.api.controller;
 
 import com.remotefalcon.api.aop.RequiresViewerAccess;
-import com.remotefalcon.api.entity.CurrentPlaylist;
-import com.remotefalcon.api.entity.PasswordReset;
 import com.remotefalcon.api.entity.Playlist;
-import com.remotefalcon.api.entity.Remote;
 import com.remotefalcon.api.entity.ViewerPageMeta;
 import com.remotefalcon.api.request.AddSequenceRequest;
 import com.remotefalcon.api.request.ViewerPageVisitRequest;
 import com.remotefalcon.api.response.AddSequenceResponse;
 import com.remotefalcon.api.response.ExternalViewerPageDetailsResponse;
-import com.remotefalcon.api.response.RemoteResponse;
 import com.remotefalcon.api.response.ViewerRemotePreferencesResponse;
-import com.remotefalcon.api.service.AccountService;
 import com.remotefalcon.api.service.ViewerPageService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @RestController
@@ -54,6 +53,7 @@ public class ViewerPageController {
 
   @PostMapping(value = "/viewer/updateActiveViewer")
   @RequiresViewerAccess
+  @SneakyThrows
   public ResponseEntity<?> updateActiveViewer(HttpServletRequest httpServletRequest) {
     return this.viewerPageService.updateActiveViewer(httpServletRequest);
   }

--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/repository/ActiveViewerRepository.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/repository/ActiveViewerRepository.java
@@ -1,7 +1,9 @@
 package com.remotefalcon.api.repository;
 
 import com.remotefalcon.api.entity.ActiveViewer;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import jakarta.transaction.Transactional;
@@ -11,6 +13,9 @@ import java.util.List;
 public interface ActiveViewerRepository extends JpaRepository<ActiveViewer, Integer> {
   @Transactional
   void deleteAllByRemoteToken(String remoteToken);
+
   List<ActiveViewer> findAllByRemoteToken(String remoteToken);
+
+  @Lock(LockModeType.PESSIMISTIC_READ)
   ActiveViewer findFirstByRemoteTokenAndViewerIp(String remoteToken, String viewerIp);
 }

--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/service/ViewerPageService.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/service/ViewerPageService.java
@@ -11,6 +11,8 @@ import com.remotefalcon.api.response.ExternalViewerPageDetailsResponse;
 import com.remotefalcon.api.response.ViewerRemotePreferencesResponse;
 import com.remotefalcon.api.util.AuthUtil;
 import com.remotefalcon.api.util.ClientUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,8 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.transaction.Transactional;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -210,7 +210,7 @@ public class ViewerPageService {
             .build();
   }
 
-  @Transactional
+  @SneakyThrows
   public ResponseEntity<?> updateActiveViewer(HttpServletRequest httpServletRequest) {
     ViewerTokenDTO viewerTokenDTO = this.authUtil.getViewerJwtPayload();
     if(viewerTokenDTO == null) {


### PR DESCRIPTION
- Added a table lock when getting the active viewer by remote token and IP. Hoping this read lock will prevent other pods from trying to update the same row a different pod has read from.