### PR TITLE
19 Viewer Page - always show hidden actions

### DIFF
--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/repository/RemoteViewerVoteRepository.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/repository/RemoteViewerVoteRepository.java
@@ -1,11 +1,10 @@
 package com.remotefalcon.api.repository;
 
-import com.remotefalcon.api.entity.Playlist;
 import com.remotefalcon.api.entity.RemoteViewerVote;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,5 +13,5 @@ public interface RemoteViewerVoteRepository extends JpaRepository<RemoteViewerVo
   @Transactional
   void deleteAllByRemoteToken(String remoteToken);
   List<RemoteViewerVote> findAllByRemoteToken(String remoteToken);
-  Optional<RemoteViewerVote> findByRemoteTokenAndViewerIp(String remoteToken, String viewerIp);
+  Optional<RemoteViewerVote> findFirstByRemoteTokenAndViewerIp(String remoteToken, String viewerIp);
 }

--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/service/ApiService.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/service/ApiService.java
@@ -208,7 +208,7 @@ public class ApiService {
       }
     }
     if(checkIfVoted) {
-      Optional<RemoteViewerVote> remoteViewerVote = this.remoteViewerVoteRepository.findByRemoteTokenAndViewerIp(externalApiAccess.getRemoteToken(), ipAddress);
+      Optional<RemoteViewerVote> remoteViewerVote = this.remoteViewerVoteRepository.findFirstByRemoteTokenAndViewerIp(externalApiAccess.getRemoteToken(), ipAddress);
       if(remoteViewerVote.isPresent()) {
         return ResponseEntity.status(202).body(AddSequenceResponse.builder().message("ALREADY_VOTED").build());
       }

--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/service/ViewerPageService.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/service/ViewerPageService.java
@@ -440,7 +440,7 @@ public class ViewerPageService {
     boolean checkIfVoted = remotePreference.getCheckIfVoted() != null && remotePreference.getCheckIfVoted();
     boolean viewerVoteSaved = false;
     if(checkIfVoted) {
-      Optional<RemoteViewerVote> remoteViewerVote = this.remoteViewerVoteRepository.findByRemoteTokenAndViewerIp(viewerTokenDTO.getRemoteToken(), ipAddress);
+      Optional<RemoteViewerVote> remoteViewerVote = this.remoteViewerVoteRepository.findFirstByRemoteTokenAndViewerIp(viewerTokenDTO.getRemoteToken(), ipAddress);
       if(remoteViewerVote.isPresent()) {
         return ResponseEntity.status(202).body(AddSequenceResponse.builder().message("ALREADY_VOTED").build());
       }else {

--- a/remote-falcon-api/src/test/java/com/remotefalcon/api/service/ViewerPageServiceTest.java
+++ b/remote-falcon-api/src/test/java/com/remotefalcon/api/service/ViewerPageServiceTest.java
@@ -770,7 +770,7 @@ public class ViewerPageServiceTest {
     when(this.clientUtil.getClientIp(any(HttpServletRequest.class))).thenReturn(ipAddress);
     when(this.remotePreferenceRepository.findByRemoteToken(eq(viewerTokenDTO.getRemoteToken()))).thenReturn(remotePreference);
     when(this.playlistRepository.findAllByRemoteToken(eq(viewerTokenDTO.getRemoteToken()))).thenReturn(playlists);
-    when(this.remoteViewerVoteRepository.findByRemoteTokenAndViewerIp(eq(viewerTokenDTO.getRemoteToken()), eq(ipAddress))).thenReturn(Optional.empty());
+    when(this.remoteViewerVoteRepository.findFirstByRemoteTokenAndViewerIp(eq(viewerTokenDTO.getRemoteToken()), eq(ipAddress))).thenReturn(Optional.empty());
 
     ResponseEntity<AddSequenceResponse> response = this.viewerPageService.voteForPlaylist(addSequenceRequest, httpServletRequest);
     assertNotNull(response);
@@ -795,7 +795,7 @@ public class ViewerPageServiceTest {
     when(this.clientUtil.getClientIp(any(HttpServletRequest.class))).thenReturn(ipAddress);
     when(this.remotePreferenceRepository.findByRemoteToken(eq(viewerTokenDTO.getRemoteToken()))).thenReturn(remotePreference);
     //when(this.playlistRepository.findAllByRemoteToken(eq(viewerTokenDTO.getRemoteToken()))).thenReturn(playlists);
-    when(this.remoteViewerVoteRepository.findByRemoteTokenAndViewerIp(eq(viewerTokenDTO.getRemoteToken()), eq(ipAddress))).thenReturn(Optional.of(remoteViewerVote));
+    when(this.remoteViewerVoteRepository.findFirstByRemoteTokenAndViewerIp(eq(viewerTokenDTO.getRemoteToken()), eq(ipAddress))).thenReturn(Optional.of(remoteViewerVote));
 
     ResponseEntity<AddSequenceResponse> response = this.viewerPageService.voteForPlaylist(addSequenceRequest, httpServletRequest);
     assertNotNull(response);

--- a/remote-falcon-web/src/views/pages/controlPanel/viewerPage/index.js
+++ b/remote-falcon-web/src/views/pages/controlPanel/viewerPage/index.js
@@ -157,7 +157,8 @@ const ViewerPage = () => {
                 ariaLabel="Actions Speedial"
                 icon={<SpeedDialIcon />}
                 onClick={() => openCloseActionsSpeedial(setOpenSpeedial, openSpeedial)}
-                open={openSpeedial}
+                open
+                hidden
                 direction="right"
               >
                 {speedialActions(
@@ -167,6 +168,7 @@ const ViewerPage = () => {
                   remoteViewerPages,
                   activeViewerPageHtml,
                   activeViewerPageName,
+                  viewerPageHtmlBase64,
                   setOpenSpeedial,
                   setIsLoading,
                   setNewViewerPageName,


### PR DESCRIPTION
https://github.com/whitesoup12/remote-falcon/issues/19
- Made it so the speed dial is always open and shows the Viewer Page actions.
- Changed remote viewer vote to fetch first result since due to an error where a row is being duplicated and retuning a non-unique record.