### PR TITLE
Add manage PSA toggle, fix blank sequence triggering PSA, and clear sequencesPlayed when clearing queue/votes

### DIFF
--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/controller/PluginController.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/controller/PluginController.java
@@ -1,8 +1,6 @@
 package com.remotefalcon.api.controller;
 
 import com.remotefalcon.api.aop.RequiresPluginAccess;
-import com.remotefalcon.api.aop.RequiresViewerAccess;
-import com.remotefalcon.api.entity.ViewerPageMeta;
 import com.remotefalcon.api.request.*;
 import com.remotefalcon.api.response.HighestVotedPlaylistResponse;
 import com.remotefalcon.api.response.NextPlaylistResponse;
@@ -11,12 +9,8 @@ import com.remotefalcon.api.response.RemotePreferenceResponse;
 import com.remotefalcon.api.service.PluginService;
 import com.remotefalcon.api.util.AuthUtil;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.repository.query.Param;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 
 @RestController
 public class PluginController {
@@ -106,5 +100,11 @@ public class PluginController {
   @RequiresPluginAccess
   public ResponseEntity<PluginResponse> updateViewerControl(@RequestBody ViewerControlRequest request) {
     return this.pluginService.updateViewerControl(request);
+  }
+
+  @PostMapping(value = "/updateManagedPsa")
+  @RequiresPluginAccess
+  public ResponseEntity<PluginResponse> updateManagedPsa(@RequestBody ManagedPSARequest request) {
+    return this.pluginService.updateManagedPsa(request);
   }
 }

--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/request/ManagedPSARequest.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/request/ManagedPSARequest.java
@@ -1,0 +1,14 @@
+package com.remotefalcon.api.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ManagedPSARequest {
+  private String managedPsaEnabled;
+}

--- a/remote-falcon-api/src/main/java/com/remotefalcon/api/service/ControlPanelService.java
+++ b/remote-falcon-api/src/main/java/com/remotefalcon/api/service/ControlPanelService.java
@@ -358,6 +358,10 @@ public class ControlPanelService {
     });
     this.playlistGroupRepository.saveAll(playlistGroups);
 
+    RemotePreference remotePreference = this.remotePreferenceRepository.findByRemoteToken(tokenDTO.getRemoteToken());
+    remotePreference.setSequencesPlayed(0);
+    this.remotePreferenceRepository.save(remotePreference);
+
     return ResponseEntity.status(200).build();
   }
 
@@ -393,6 +397,11 @@ public class ControlPanelService {
     this.playlistGroupRepository.saveAll(playlistGroups.stream().toList());
     List<RemoteViewerVote> remoteViewerVotes = this.remoteViewerVoteRepository.findAllByRemoteToken(tokenDTO.getRemoteToken());
     this.remoteViewerVoteRepository.deleteAll(remoteViewerVotes.stream().toList());
+
+    RemotePreference remotePreference = this.remotePreferenceRepository.findByRemoteToken(tokenDTO.getRemoteToken());
+    remotePreference.setSequencesPlayed(0);
+    this.remotePreferenceRepository.save(remotePreference);
+
     return ResponseEntity.status(200).build();
   }
 

--- a/remote-falcon-api/src/test/java/com/remotefalcon/api/service/ControlPanelServiceTest.java
+++ b/remote-falcon-api/src/test/java/com/remotefalcon/api/service/ControlPanelServiceTest.java
@@ -405,8 +405,10 @@ public class ControlPanelServiceTest {
   @Test
   public void purgeQueue() {
     TokenDTO tokenDTO = Mocks.tokenDTO();
+    RemotePreference remotePreference = Mocks.remotePreference();
 
     when(this.authUtil.getJwtPayload()).thenReturn(tokenDTO);
+    when(this.remotePreferenceRepository.findByRemoteToken(tokenDTO.getRemoteToken())).thenReturn(remotePreference);
 
     ResponseEntity<?> response = this.controlPanelService.purgeQueue();
     assertNotNull(response);
@@ -453,8 +455,10 @@ public class ControlPanelServiceTest {
     List<Playlist> sequences = Mocks.sequences();
     List<RemoteViewerVote> remoteViewerVotes = Mocks.remoteViewerVotes();
     List<PlaylistGroup> playlistGroupList = Mocks.playlistGroupList();
+    RemotePreference remotePreference = Mocks.remotePreference();
 
     when(this.authUtil.getJwtPayload()).thenReturn(tokenDTO);
+    when(this.remotePreferenceRepository.findByRemoteToken(tokenDTO.getRemoteToken())).thenReturn(remotePreference);
     when(this.playlistRepository.findAllByRemoteTokenAndIsSequenceActiveOrderBySequenceOrderAsc(eq(tokenDTO.getRemoteToken()), eq(true))).thenReturn(sequences);
     when(this.remoteViewerVoteRepository.findAllByRemoteToken(eq(tokenDTO.getRemoteToken()))).thenReturn(remoteViewerVotes);
     when(this.playlistGroupRepository.findAllByRemoteToken(eq(tokenDTO.getRemoteToken()))).thenReturn(playlistGroupList);

--- a/remote-falcon-api/src/test/java/com/remotefalcon/api/service/PluginServiceTest.java
+++ b/remote-falcon-api/src/test/java/com/remotefalcon/api/service/PluginServiceTest.java
@@ -446,11 +446,9 @@ public class PluginServiceTest {
   public void updateWhatsPlaying_noPlaylist() {
     String remoteToken = "abc123";
     UpdateWhatsPlayingRequest updateWhatsPlayingRequest = Mocks.updateWhatsPlayingRequest();
-    RemotePreference remotePreference = Mocks.remotePreference();
     updateWhatsPlayingRequest.setPlaylist(null);
 
     when(this.authUtil.getRemoteTokenFromHeader()).thenReturn(remoteToken);
-    when(this.remotePreferenceRepository.findByRemoteToken(remoteToken)).thenReturn(remotePreference);
 
     ResponseEntity<PluginResponse> response = this.pluginService.updateWhatsPlaying(updateWhatsPlayingRequest);
     assertNotNull(response);


### PR DESCRIPTION
- Added a new endpoint for toggling Managed PSA from FPP (available in plugin version 1.0.6).
- Fixed issues where a blank now playing can cause PSA sequences to be triggered.
- Clearing the sequencesPlayed value (used for PSA triggers) when deleting all requests or resetting votes.