### PR TITLE
Improvement/Increase-HikariPool-Size

### DIFF
--- a/remote-falcon-api/src/main/resources/bootstrap.yml
+++ b/remote-falcon-api/src/main/resources/bootstrap.yml
@@ -17,7 +17,7 @@ spring:
   datasource:
     url: jdbc:${DATABASE_URL}
     hikari:
-      maximum-pool-size: 50
+      maximum-pool-size: 75
 
 management:
   endpoints:


### PR DESCRIPTION
This PR implements an important upgrade in our Hikari database connection pool configuration by increasing the maximum pool size.

The main changes in this PR are as follows:

The max pool size parameter in the Hikari configuration has been updated from 50 to 75.
This change enhances our application's capacity to manage multiple database connections concurrently.
By allowing more simultaneous connections, we expect to see an overall improvement in the application's performance, especially under high load.

Commit Reference: 0323b1d511ee8650004c4e6e969e5ca2eef2d5ea