### PR TITLE
Configurable Maximum Pool Size in Hikari Datasource Configuration

### DIFF
--- a/remote-falcon-api/src/main/resources/bootstrap.yml
+++ b/remote-falcon-api/src/main/resources/bootstrap.yml
@@ -17,7 +17,7 @@ spring:
   datasource:
     url: jdbc:${DATABASE_URL}
     hikari:
-      maximum-pool-size: 75
+      maximum-pool-size: ${CONNECTION_POOL_SIZE}
 
 management:
   endpoints:


### PR DESCRIPTION
This pull request introduces flexibility in the configuration of the maximum pool size value in the Hikari Datasource Configuration, which was previously hardcoded at 75.

Now, by enabling this value to be configurable, it accommodates easier adjustments for different environments. The relevant changes can be found in the updated bootstrap.yml file.